### PR TITLE
Raise test quality bar: coverage gate and diagnostic assertions

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -4,7 +4,7 @@
 
 Test:
   CodeCoverage:
-    PercentTarget: 25
+    PercentTarget: 80
 #   TestResults:
 #     Skip: true
 #   SourceCode:

--- a/tests/ConvertFrom-Yaml.Tests.ps1
+++ b/tests/ConvertFrom-Yaml.Tests.ps1
@@ -467,14 +467,18 @@ date: !!timestamp 2001-12-14
 
 Context 'Validation and limits' {
     It 'rejects duplicate scalar, canonical numeric, and complex keys' {
-        { "key: one`nkey: two" | ConvertFrom-Yaml } | Should -Throw
-        { "1: one`n01: two" | ConvertFrom-Yaml -AsHashtable } | Should -Throw
-        { "1.0: one`n1.00: two" | ConvertFrom-Yaml -AsHashtable } | Should -Throw
-        { "1.0: one`n1e0: two" | ConvertFrom-Yaml -AsHashtable } | Should -Throw
+        { "key: one`nkey: two" | ConvertFrom-Yaml } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
+        { "1: one`n01: two" | ConvertFrom-Yaml -AsHashtable } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
+        { "1.0: one`n1.00: two" | ConvertFrom-Yaml -AsHashtable } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
+        { "1.0: one`n1e0: two" | ConvertFrom-Yaml -AsHashtable } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
         { "? [a, b]`n: one`n? [a, b]`n: two" | ConvertFrom-Yaml -AsHashtable } |
-            Should -Throw
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
         { "? {a: 1, A: 1}`n: one`n? {A: 1, a: 1}`n: two" | ConvertFrom-Yaml -AsHashtable } |
-            Should -Throw
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
     }
 
     It 'normalizes cross-type finite floats for key equality' {
@@ -507,7 +511,8 @@ Context 'Validation and limits' {
 : two
 '@
 
-        { $yaml | ConvertFrom-Yaml -AsHashtable } | Should -Throw
+        { $yaml | ConvertFrom-Yaml -AsHashtable } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
         ($yaml | Test-Yaml) | Should -BeFalse
     }
 
@@ -519,7 +524,8 @@ Context 'Validation and limits' {
 : two
 '@
 
-        { $yaml | ConvertFrom-Yaml -AsHashtable } | Should -Throw
+        { $yaml | ConvertFrom-Yaml -AsHashtable } |
+            Should -Throw -ExpectedMessage '*duplicate mapping key*'
         ($yaml | Test-Yaml) | Should -BeFalse
     }
 
@@ -530,14 +536,19 @@ Context 'Validation and limits' {
     }
 
     It 'rejects undefined aliases' {
-        { 'value: *missing' | ConvertFrom-Yaml } | Should -Throw
+        { 'value: *missing' | ConvertFrom-Yaml } |
+            Should -Throw -ExpectedMessage '*does not refer to a preceding anchor*'
     }
 
     It 'enforces depth, node, alias, and scalar limits' {
-        { "a:`n  b:`n    c: value" | ConvertFrom-Yaml -Depth 2 } | Should -Throw
-        { "[one, two]" | ConvertFrom-Yaml -MaxNodes 2 } | Should -Throw
-        { "a: &a value`nb: *a" | ConvertFrom-Yaml -MaxAliases 0 } | Should -Throw
-        { 'value: long' | ConvertFrom-Yaml -MaxScalarLength 4 } | Should -Throw
+        { "a:`n  b:`n    c: value" | ConvertFrom-Yaml -Depth 2 } |
+            Should -Throw -ExpectedMessage '*configured limit of 2*'
+        { "[one, two]" | ConvertFrom-Yaml -MaxNodes 2 } |
+            Should -Throw -ExpectedMessage '*configured limit of 2 nodes*'
+        { "a: &a value`nb: *a" | ConvertFrom-Yaml -MaxAliases 0 } |
+            Should -Throw -ExpectedMessage '*configured limit of 0 aliases*'
+        { 'value: long' | ConvertFrom-Yaml -MaxScalarLength 4 } |
+            Should -Throw -ExpectedMessage '*configured limit of 4 characters*'
     }
 
     It 'enforces tag and numeric limits before expensive construction' {

--- a/tests/ConvertTo-Yaml.Tests.ps1
+++ b/tests/ConvertTo-Yaml.Tests.ps1
@@ -550,9 +550,12 @@ Describe 'ConvertTo-Yaml' {
         It 'enforces depth, node, and scalar limits without truncating' {
             $nested = [ordered]@{ a = [ordered]@{ b = [ordered]@{ c = 1 } } }
 
-            { $nested | ConvertTo-Yaml -Depth 2 } | Should -Throw
-            { @(1, 2) | ConvertTo-Yaml -MaxNodes 2 } | Should -Throw
-            { 'long' | ConvertTo-Yaml -MaxScalarLength 3 } | Should -Throw
+            { $nested | ConvertTo-Yaml -Depth 2 } |
+                Should -Throw -ExpectedMessage '*configured depth limit of 2*'
+            { @(1, 2) | ConvertTo-Yaml -MaxNodes 2 } |
+                Should -Throw -ExpectedMessage '*configured limit of 2 nodes*'
+            { 'long' | ConvertTo-Yaml -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
         }
 
         It 'stops infinite pipelines at the node budget' {
@@ -649,15 +652,22 @@ Describe 'ConvertTo-Yaml' {
         It 'enforces the scalar limit for every emitted scalar kind' {
             $bigInteger = [System.Numerics.BigInteger]::Parse('12345')
 
-            { ConvertTo-Yaml -InputObject $null -MaxScalarLength 3 } | Should -Throw
-            { ConvertTo-Yaml -InputObject $true -MaxScalarLength 3 } | Should -Throw
-            { ConvertTo-Yaml -InputObject $bigInteger -MaxScalarLength 4 } | Should -Throw
-            { ConvertTo-Yaml -InputObject ([decimal] 12.5) -MaxScalarLength 3 } | Should -Throw
-            { ConvertTo-Yaml -InputObject ([double]::PositiveInfinity) -MaxScalarLength 3 } | Should -Throw
-            { ConvertTo-Yaml -InputObject ([datetime]::UtcNow) -MaxScalarLength 10 } | Should -Throw
-            { ConvertTo-Yaml -InputObject ([byte[]] @(1, 2, 3)) -MaxScalarLength 3 } | Should -Throw
+            { ConvertTo-Yaml -InputObject $null -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
+            { ConvertTo-Yaml -InputObject $true -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
+            { ConvertTo-Yaml -InputObject $bigInteger -MaxScalarLength 4 } |
+                Should -Throw -ExpectedMessage '*configured limit of 4 characters*'
+            { ConvertTo-Yaml -InputObject ([decimal] 12.5) -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
+            { ConvertTo-Yaml -InputObject ([double]::PositiveInfinity) -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
+            { ConvertTo-Yaml -InputObject ([datetime]::UtcNow) -MaxScalarLength 10 } |
+                Should -Throw -ExpectedMessage '*configured limit of 10 characters*'
+            { ConvertTo-Yaml -InputObject ([byte[]] @(1, 2, 3)) -MaxScalarLength 3 } |
+                Should -Throw -ExpectedMessage '*configured limit of 3 characters*'
             { ConvertTo-Yaml -InputObject ([DayOfWeek]::Monday) -EnumsAsStrings -MaxScalarLength 5 } |
-                Should -Throw
+                Should -Throw -ExpectedMessage '*configured limit of 5 characters*'
         }
     }
 }


### PR DESCRIPTION
## Summary

Brings the test suite closer to production-grade standards by raising the code coverage gate to match measured coverage and tightening several bare `Should -Throw` assertions so failures are diagnostic.

## Changes

- `.github/PSModule.yml`: raise `Test.CodeCoverage.PercentTarget` from `25` to `80`.
- `tests/ConvertFrom-Yaml.Tests.ps1`: add `-ExpectedMessage` patterns for duplicate-key, undefined-alias, and resource-limit error cases.
- `tests/ConvertTo-Yaml.Tests.ps1`: add `-ExpectedMessage` patterns for depth, node, and scalar limit error cases.

## Validation

- Ran `ConvertFrom-Yaml.Tests.ps1` and `ConvertTo-Yaml.Tests.ps1`: **109 passed, 0 failed**.
- Full suite previously measured **85.24% code coverage** with **405 passed, 0 failed, 4 skipped** (skipped tests are platform-specific filesystem cases).

## Related

- Quality review identified the 25% coverage target as below production grade.